### PR TITLE
Fix header shrinking magic.

### DIFF
--- a/source/javascripts/all.js
+++ b/source/javascripts/all.js
@@ -5,7 +5,7 @@
 $(document).ready(function() {
 	window.addEventListener('scroll', function(e){
         var distanceY = window.pageYOffset || document.documentElement.scrollTop,
-            shrinkOn = 300,
+            shrinkOn = 60,
             header = document.querySelector("header");
         if (distanceY > shrinkOn) {
         	$("header").addClass("smaller");


### PR DESCRIPTION
Shrink header when content is just about to become hidden, instead of after an entire paragraph is hidden.
