### PR TITLE
Reordering page list to prevent invalid atom.xml

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -41,8 +41,8 @@ end
 
 activate :directory_indexes
 
-page "/blog/atom.xml", layout: false
 page "/blog/*", layout: "blog"
+page "/blog/atom.xml", layout: false
 page "/wiki/*", layout: "wiki"
 page "/404.html", directory_index: false
 


### PR DESCRIPTION
It seems having page "/blog/*" defined after page "/blog/atom.xml" overwrites layout: false and wraps your atom feed in html making it invalid.